### PR TITLE
workaround for buggy --warning-as-errors in Elixir 1.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,18 +39,28 @@ jobs:
           - elixir: 1.10.0
             otp: 21.3.8.16
             os: alpine-3.12.0
+            buggy_warnings_as_errors_return_value: true
           - elixir: 1.10.0
             otp: 22.3.4.4
             os: alpine-3.12.0
+            buggy_warnings_as_errors_return_value: true
           - elixir: 1.10.4
             otp: 21.3.8.16
             os: alpine-3.12.0
+            buggy_warnings_as_errors_return_value: true
           - elixir: 1.10.4
             otp: 22.3.4.4
             os: alpine-3.12.0
+            buggy_warnings_as_errors_return_value: true
           - elixir: 1.10.4
             otp: 23.0.3
             os: alpine-3.12.0
+            buggy_warnings_as_errors_return_value: true
     steps:
       - uses: actions/checkout@v2.3.1
       - run: mix compile --warnings-as-errors
+      - name: Workaround for buggy `mix compile --warnings-as-errors` on Elixir 1.10
+        run: |
+          source workaround_buggy_warnings_as_errors_return_value.sh
+          workaround_buggy_warnings_as_errors_return_value
+        if: matrix.buggy_warnings_as_errors_return_value

--- a/workaround_buggy_warnings_as_errors_return_value.sh
+++ b/workaround_buggy_warnings_as_errors_return_value.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+workaround_buggy_warnings_as_errors_return_value() {
+  _TEMP_FILE=$(mktemp mix_compile_stderr.XXXXXXXX)
+
+  # deletes all build artifacts for the current project to ensure they are
+  # actually compiled and applicable warnings generated
+  mix clean
+
+  # prevents warnings in dependencies from being confused with warnings in the current project
+  mix deps.compile
+
+  # the following pair of lines emulate the behaviour of tee for stderr
+  mix compile 2> "$_TEMP_FILE"
+  cat "$_TEMP_FILE" 1>&2
+
+  grep -lq "warning:" "$_TEMP_FILE"
+  _GREP_RETURN_VALUE=$?
+
+  rm "$_TEMP_FILE"
+
+  if [ $_GREP_RETURN_VALUE -eq 0 ]; then
+    return 1
+  else
+    return 0
+  fi
+}

--- a/workaround_buggy_warnings_as_errors_return_value.sh
+++ b/workaround_buggy_warnings_as_errors_return_value.sh
@@ -3,15 +3,11 @@
 workaround_buggy_warnings_as_errors_return_value() {
   _TEMP_FILE=$(mktemp mix_compile_stderr.XXXXXXXX)
 
-  # deletes all build artifacts for the current project to ensure they are
-  # actually compiled and applicable warnings generated
-  mix clean
-
   # prevents warnings in dependencies from being confused with warnings in the current project
   mix deps.compile
 
   # the following pair of lines emulate the behaviour of tee for stderr
-  mix compile 2> "$_TEMP_FILE"
+  mix compile --force 2> "$_TEMP_FILE"
   cat "$_TEMP_FILE" 1>&2
 
   grep -lq "warning:" "$_TEMP_FILE"


### PR DESCRIPTION
Workaround the fact, described in https://github.com/elixir-lang/elixir/issues/10073, that `mix compile --warnings-as-errors` in Elixir 1.10 returns zero even if there are warnings by scanning the stderr output of the compilation in search of `warnings:`.

PS: the checks should all fail.